### PR TITLE
Multi variate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.log
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -4,17 +4,8 @@ This Telegraf output plugin is a general purpose output plugin for the [Apache A
 
 ## Arrow Schema
 
-The plugin currently supports outputting data points with the following schema:
-
-```go
-schema:
-  fields: 3
-    - tid: type=int32 // Unused and deprecated time series identifier.
-    - timestamp: type=timestamp[ms]
-    - value: type=float32
-```
-
-Support for arbitrary schemas is planned.
+The plugin currently supports outputting data points to any schema retrived from the table defined in the configuration.
+It assumes that any string defined in the schema is a tag in the Telegraf metric.
 
 ## Setting up and running the plugin
 
@@ -60,5 +51,4 @@ The following configuration is a [sample configuration](\plugins\output\flight\s
 ```
 ## Known issues and limitations
 
-* Currently, the plugin only implements support for the simplest schema supported by legacy JVM and current Rust versions of [ModelarDB](https://github.com/ModelarData/ModelarDB-RS), as listed above. Support for an arbitrary schema is planned.
 * This plugin is not compatible with the Rust implementation of Apache Arrow Flight, because a [bug](https://github.com/apache/arrow-rs/issues/2445) is present in the Rust implementation of Apache Arrow Flight where the schema is not serialized properly.

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -3,7 +3,6 @@ package flight
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"net"
 
 	"github.com/apache/arrow/go/v9/arrow"
@@ -57,7 +56,6 @@ func (f *Flight) Write(metrics []telegraf.Metric) error {
 		timeInt := m.Time().UnixMilli()
 
 		for i, f := range schemaFields {
-			fmt.Println(f.Name)
 			switch f.Type.ID() {
 			case arrow.TIMESTAMP:
 				builder.Field(i).(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{arrow.Timestamp(timeInt)}, nil)

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -205,6 +205,7 @@ func getTag(metric telegraf.Metric, schemaField arrow.Field, i int) string {
 	metricTag, wasSet := metric.GetTag(schemaField.Name)
 	// If the tag is not set, the program will panic.
 	// This is to prevent the plugin from attempting a retransmit.
+	// a retransmit if the recuired value is missing.
 	if !wasSet {
 		panic(fmt.Sprintf("tag %d : %s not set", i, schemaField.Name))
 	}
@@ -215,7 +216,8 @@ func getTag(metric telegraf.Metric, schemaField arrow.Field, i int) string {
 func getField(metric telegraf.Metric, schemaField arrow.Field, i int) interface{} {
 	metricField, wasSet := metric.GetField(schemaField.Name)
 	// If the field is not set, the program will panic.
-	// This is to prevent the plugin from attempting a retransmit.
+	// This is to prevent the plugin from attempting
+	// a retransmit if the recuired value is missing.
 	if !wasSet {
 		panic(fmt.Sprintf("field %d : %s not set", i, schemaField.Name))
 	}

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -3,6 +3,7 @@ package flight
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"net"
 
 	"github.com/apache/arrow/go/v9/arrow"
@@ -59,29 +60,71 @@ func (f *Flight) Write(metrics []telegraf.Metric) error {
 			switch f.Type.ID() {
 			case arrow.TIMESTAMP:
 				builder.Field(i).(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{arrow.Timestamp(timeInt)}, nil)
+			case arrow.STRING:
+				tag, wasSet := m.GetTag(f.Name)
+				if !wasSet {
+					fmt.Printf("tag %d : %s not set", i, f.Name)
+				}
+				builder.Field(i).(*array.StringBuilder).AppendValues([]string{tag}, nil)
 			case arrow.INT32:
-				for _, field := range m.FieldList() {
-					if field.Key == f.Name {
-						builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(field.Value.(float64))}, nil)
-					}
+				field, wasSet := m.GetField(f.Name)
+				if !wasSet {
+					fmt.Printf("field %d : %s not set", i, f.Name)
+				}
+				switch v := field.(type) {
+				case int32:
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{v}, nil)
+				case int64:
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
+				case float32:
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
+				case float64:
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
 				}
 			case arrow.INT64:
-				for _, field := range m.FieldList() {
-					if field.Key == f.Name {
-						builder.Field(i).(*array.Int64Builder).AppendValues([]int64{field.Value.(int64)}, nil)
-					}
+				field, wasSet := m.GetField(f.Name)
+				if !wasSet {
+					fmt.Printf("field %d : %s not set", i, f.Name)
+				}
+				switch v := field.(type) {
+				case int32:
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
+				case int64:
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{v}, nil)
+				case float32:
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
+				case float64:
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
 				}
 			case arrow.FLOAT32:
-				for _, field := range m.FieldList() {
-					if field.Key == f.Name {
-						builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(field.Value.(float64))}, nil)
-					}
+				field, wasSet := m.GetField(f.Name)
+				if !wasSet {
+					fmt.Printf("field %d : %s not set", i, f.Name)
+				}
+				switch v := field.(type) {
+				case int32:
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
+				case int64:
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
+				case float32:
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{v}, nil)
+				case float64:
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
 				}
 			case arrow.FLOAT64:
-				for _, field := range m.FieldList() {
-					if field.Key == f.Name {
-						builder.Field(i).(*array.Float64Builder).AppendValues([]float64{field.Value.(float64)}, nil)
-					}
+				field, wasSet := m.GetField(f.Name)
+				if !wasSet {
+					fmt.Printf("field %d : %s not set", i, f.Name)
+				}
+				switch v := field.(type) {
+				case int32:
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+				case int64:
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+				case float32:
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+				case float64:
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{v}, nil)
 				}
 			}
 		}

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -204,8 +204,8 @@ func addMetricToRecordBuilder(schemaFields []arrow.Field, builder *array.RecordB
 func getTag(metric telegraf.Metric, schemaField arrow.Field, i int) string {
 	metricTag, wasSet := metric.GetTag(schemaField.Name)
 	// If the tag is not set, the program will panic.
-	// This is to prevent the plugin from attempting a retransmit.
-	// a retransmit if the recuired value is missing.
+	// This is to prevent Telegraf from attempting to
+	// retransmit metric when the required value is missing.
 	if !wasSet {
 		panic(fmt.Sprintf("tag %d : %s not set", i, schemaField.Name))
 	}
@@ -216,8 +216,8 @@ func getTag(metric telegraf.Metric, schemaField arrow.Field, i int) string {
 func getField(metric telegraf.Metric, schemaField arrow.Field, i int) interface{} {
 	metricField, wasSet := metric.GetField(schemaField.Name)
 	// If the field is not set, the program will panic.
-	// This is to prevent the plugin from attempting
-	// a retransmit if the recuired value is missing.
+	// This is to prevent Telegraf from attempting to
+	// retransmit metric when the required value is missing.
 	if !wasSet {
 		panic(fmt.Sprintf("field %d : %s not set", i, schemaField.Name))
 	}

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -44,14 +44,11 @@ type Flight struct {
 // (Telegraf manages the buffer for you). Returning an error will fail this
 // batch of writes and the entire batch will be retried automatically.
 func (f *Flight) Write(metrics []telegraf.Metric) error {
-	fmt.Println(len(metrics))
 
 	builder := array.NewRecordBuilder(memory.DefaultAllocator, &f.schema)
 	defer builder.Release()
 
 	schemaFields := f.schema.Fields()
-
-	fmt.Println(schemaFields)
 
 	builder.Reserve(len(metrics))
 
@@ -91,8 +88,6 @@ func (f *Flight) Write(metrics []telegraf.Metric) error {
 			}
 		}
 	}
-
-	fmt.Println(builder.Fields())
 
 	rec := builder.NewRecord()
 	defer rec.Release()

--- a/plugins/output/flight/flight.go
+++ b/plugins/output/flight/flight.go
@@ -45,6 +45,7 @@ type Flight struct {
 // batch of writes and the entire batch will be retried automatically.
 func (f *Flight) Write(metrics []telegraf.Metric) error {
 
+	// Create a new RecordBuilder using the schema.
 	builder := array.NewRecordBuilder(memory.DefaultAllocator, &f.schema)
 	defer builder.Release()
 
@@ -52,88 +53,102 @@ func (f *Flight) Write(metrics []telegraf.Metric) error {
 
 	builder.Reserve(len(metrics))
 
-	for _, m := range metrics {
+	// Iterate through the metrics and add them to the RecordBuilder.
+	for _, metric := range metrics {
 
-		timeInt := m.Time().UnixMilli()
+		timeInt := metric.Time().UnixMilli()
 
-		for i, f := range schemaFields {
-			switch f.Type.ID() {
+		// Iterate through the fields in the schema, extract the tag or field
+		// values from the metric using getTag or getField,
+		// and add the corresponding value to the correct builder in RecordBuilder.
+		// If the value is not set in the metric, panic and print the error.
+		//
+		// The switches for the types inside each case are necessary because the type
+		// represented by the schema is not always the same as the type represented by the metric.
+		// For example, JSON does not define types and therefore parses all integers
+		// as floats. If the schema expects an integer in the field, Apache Arrow will panic.
+		for i, schemaField := range schemaFields {
+			switch schemaField.Type.ID() {
 			case arrow.TIMESTAMP:
 				builder.Field(i).(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{arrow.Timestamp(timeInt)}, nil)
 			case arrow.STRING:
-				tag, wasSet := m.GetTag(f.Name)
-				if !wasSet {
-					fmt.Printf("tag %d : %s not set", i, f.Name)
-				}
-				builder.Field(i).(*array.StringBuilder).AppendValues([]string{tag}, nil)
+				metricTag := getTag(metric, schemaField, i)
+				builder.Field(i).(*array.StringBuilder).AppendValues([]string{metricTag}, nil)
 			case arrow.INT32:
-				field, wasSet := m.GetField(f.Name)
-				if !wasSet {
-					fmt.Printf("field %d : %s not set", i, f.Name)
-				}
-				switch v := field.(type) {
+				metricField := getField(metric, schemaField, i)
+				switch value := metricField.(type) {
 				case int32:
-					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{v}, nil)
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{value}, nil)
 				case int64:
-					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(value)}, nil)
 				case float32:
-					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(value)}, nil)
 				case float64:
-					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(v)}, nil)
+					builder.Field(i).(*array.Int32Builder).AppendValues([]int32{int32(value)}, nil)
 				}
 			case arrow.INT64:
-				field, wasSet := m.GetField(f.Name)
-				if !wasSet {
-					fmt.Printf("field %d : %s not set", i, f.Name)
-				}
-				switch v := field.(type) {
+				metricField := getField(metric, schemaField, i)
+				switch value := metricField.(type) {
 				case int32:
-					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(value)}, nil)
 				case int64:
-					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{v}, nil)
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{value}, nil)
 				case float32:
-					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(value)}, nil)
 				case float64:
-					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(v)}, nil)
+					builder.Field(i).(*array.Int64Builder).AppendValues([]int64{int64(value)}, nil)
 				}
 			case arrow.FLOAT32:
-				field, wasSet := m.GetField(f.Name)
-				if !wasSet {
-					fmt.Printf("field %d : %s not set", i, f.Name)
-				}
-				switch v := field.(type) {
+				metricField := getField(metric, schemaField, i)
+				switch value := metricField.(type) {
 				case int32:
-					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(value)}, nil)
 				case int64:
-					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(value)}, nil)
 				case float32:
-					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{v}, nil)
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{value}, nil)
 				case float64:
-					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(v)}, nil)
+					builder.Field(i).(*array.Float32Builder).AppendValues([]float32{float32(value)}, nil)
 				}
 			case arrow.FLOAT64:
-				field, wasSet := m.GetField(f.Name)
-				if !wasSet {
-					fmt.Printf("field %d : %s not set", i, f.Name)
-				}
-				switch v := field.(type) {
+				metricField := getField(metric, schemaField, i)
+				switch value := metricField.(type) {
 				case int32:
-					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(value)}, nil)
 				case int64:
-					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(value)}, nil)
 				case float32:
-					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(v)}, nil)
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{float64(value)}, nil)
 				case float64:
-					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{v}, nil)
+					builder.Field(i).(*array.Float64Builder).AppendValues([]float64{value}, nil)
 				}
 			}
 		}
 	}
 
+	// Create a new Record from the RecordBuilder.
 	rec := builder.NewRecord()
 	defer rec.Release()
 
 	return f.writer.Write(rec)
+}
+
+// getTag returns the value of the metric tag with the name equal to the name of the schema field.
+func getTag(metric telegraf.Metric, schemaField arrow.Field, i int) string {
+	metricTag, wasSet := metric.GetTag(schemaField.Name)
+	if !wasSet {
+		panic(fmt.Sprintf("tag %d : %s not set", i, schemaField.Name))
+	}
+	return metricTag
+}
+
+// getField returns the value of the metric field with the name equal to the name of the schema field.
+func getField(metric telegraf.Metric, schemaField arrow.Field, i int) interface{} {
+	metricField, wasSet := metric.GetField(schemaField.Name)
+	if !wasSet {
+		panic(fmt.Sprintf("field %d : %s not set", i, schemaField.Name))
+	}
+	return metricField
 }
 
 // Connect to the Apache Arrow Flight server. If an error is at any point returned


### PR DESCRIPTION
This PR adds support for creating a record builder from any schema retrieved through `GetSchema`.

Currently, the plugin expects any string found in the schema to be a tag from the telegraf metric, as I couldn't think of a situation where a string in the schema would be a field in the metric and not a tag. If you don't agree, please advise.

As you can see in the following image, the output plugin is currently able to send metrics at a rate of about one metric every 10-15 microseconds:
![image](https://user-images.githubusercontent.com/43062786/187199670-0b25d453-e109-4366-ab2c-f88ffdc25e7b.png)
