### PR TITLE
Cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ To build the binary and run the plugin:
 4. Extract the Telegraf binaries and configuration to the repository folder.
 5. Configure the `telegraf.conf` file:
    * In `telegraf.conf`, remove the comment in front of the tag `[[outputs.execd]]` and the option `command`.
-     * Windows: Assign the following to `command` so the resulting line becomes:  
-      `command = ["/path/to/flight.exe", "-config", "/path/to/sample.conf"]` 
-     * Linux/macOS: Assign the following to `command` so the resulting line becomes:  
-      `command = ["/path/to/flight", "-config", "/path/to/sample.conf"]` 
+     * Windows: Assign the following to `command` so the resulting line becomes:
+      `command = ["/path/to/flight.exe", "-config", "/path/to/sample.conf"]`
+     * Linux/macOS: Assign the following to `command` so the resulting line becomes:
+      `command = ["/path/to/flight", "-config", "/path/to/sample.conf"]`
    * Configure any input plugin to consume metrics. (The metric must adhere to the schema presented in this README)
 6. Configure the [sample configuration](\plugins\output\flight\sample.conf) to connect to the desired server, and designate the desired table to store metrics in.
 7. Run the plugin using Telegraf: `telegraf --config telegraf.conf --input-filter chosen_input_plugin --output-filter execd`
 
-To run the tests: 
+To run the tests:
 1. Install the latest version of [Go](https://go.dev/doc/install).
 2. Start an Apache Arrow Flight Server.
 3. Run the command: `go test plugins/output/flight/flight_test.go plugins/output/flight/flight.go`
@@ -45,7 +45,7 @@ The following configuration is a [sample configuration](\plugins\output\flight\s
 
     ## Port to connect to.
     port = "9999"
-    
+
     ## Name of the table to store the metrics in.
     table = "data"
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build the binary and run the plugin:
      * Linux/macOS: Assign the following to `command` so the resulting line becomes:
       `command = ["/path/to/flight", "-config", "/path/to/sample.conf"]`
    * Configure any input plugin to consume metrics. (The metric must adhere to the schema presented in this README)
-6. Configure the [sample configuration](\plugins\output\flight\sample.conf) to connect to the desired server, and designate the desired table to store metrics in.
+6. Configure the [sample configuration](/plugins/output/flight/sample.conf) to connect to the desired server, and designate the desired table to store metrics in.
 7. Run the plugin using Telegraf: `telegraf --config telegraf.conf --input-filter chosen_input_plugin --output-filter execd`
 
 To run the tests:
@@ -35,7 +35,7 @@ To run the tests:
 
 ## Configuration
 
-The following configuration is a [sample configuration](\plugins\output\flight\sample.conf) used to connect to the Arrow Flight Server and configure what table to insert the data into.
+The following configuration is a [sample configuration](/plugins/output/flight/sample.conf) used to connect to the Arrow Flight Server and configure what table to insert the data into.
 
 ```toml @sample.conf
 ## Configuration for where the Arrow Flight Client will send metrics to.
@@ -51,4 +51,5 @@ The following configuration is a [sample configuration](\plugins\output\flight\s
 ```
 
 ## License
+
 The Apache Arrow Flight Telegraf Output Plugin is licensed under version 2.0 of the Apache License and a copy of the license is bundled with the program.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,3 @@ The following configuration is a [sample configuration](\plugins\output\flight\s
     ## Name of the table to store the metrics in.
     table = "data"
 ```
-## Known issues and limitations
-
-* This plugin is not compatible with the Rust implementation of Apache Arrow Flight, because a [bug](https://github.com/apache/arrow-rs/issues/2445) is present in the Rust implementation of Apache Arrow Flight where the schema is not serialized properly.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 This Telegraf output plugin is a general purpose output plugin for the [Apache Arrow Flight protocol](https://arrow.apache.org/docs/format/Flight.html).
 
-## Arrow Schema
+## Overview
 
-The plugin currently supports outputting data points to any schema retrived from the table defined in the configuration.
-It assumes that any string defined in the schema is a tag in the Telegraf metric.
+The plugin currently supports outputting Telegraf metrics to the Apache Arrow Flight server and table specified in the [sample configuration](/plugins/output/flight/sample.conf).
+It uses the type of each column in the table to determine which part of the metrics should be assigned to that column.
+If the column has the type `TIMESTAMP` `metric.Time().UnixMilli()` is assigned to it, if the column has the type `STRING` the tag with the same name is assigned to it, for columns of all other types the field with the same name is assigned to it.
 
-## Setting up and running the plugin
+## Installation
 
 To build the binary and run the plugin:
 
@@ -24,18 +25,18 @@ To build the binary and run the plugin:
      * Linux/macOS: Assign the following to `command` so the resulting line becomes:
       `command = ["/path/to/flight", "-config", "/path/to/sample.conf"]`
    * Configure any input plugin to consume metrics. (The metric must adhere to the schema presented in this README)
-6. Configure the [sample configuration](/plugins/output/flight/sample.conf) to connect to the desired server, and designate the desired table to store metrics in.
+6. Update the [sample configuration](/plugins/output/flight/sample.conf) to specify the Apache Arrow Flight server to connect to and the table to insert metrics into.
 7. Run the plugin using Telegraf: `telegraf --config telegraf.conf --input-filter chosen_input_plugin --output-filter execd`
 
 To run the tests:
 1. Install the latest version of [Go](https://go.dev/doc/install).
-2. Start an Apache Arrow Flight Server.
+2. Start an Apache Arrow Flight Server on port 9999.
 3. Run the command: `go test plugins/output/flight/flight_test.go plugins/output/flight/flight.go`
 
 
 ## Configuration
 
-The following configuration is a [sample configuration](/plugins/output/flight/sample.conf) used to connect to the Arrow Flight Server and configure what table to insert the data into.
+The following configuration is a [sample configuration](/plugins/output/flight/sample.conf) used to specify the Arrow Flight server to connect to and the table to insert metrics into.
 
 ```toml @sample.conf
 ## Configuration for where the Arrow Flight Client will send metrics to.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ The following configuration is a [sample configuration](\plugins\output\flight\s
     ## Name of the table to store the metrics in.
     table = "data"
 ```
+
+## License
+The Apache Arrow Flight Telegraf Output Plugin is licensed under version 2.0 of the Apache License and a copy of the license is bundled with the program.


### PR DESCRIPTION
This PR removes outdated information from the README, makes the plugin's license explicit, extends the description of how it works, fixes a few broken links, and removes leftover whitespace.
